### PR TITLE
Update sync API version from v8 to v9

### DIFF
--- a/todoist/api.py
+++ b/todoist/api.py
@@ -35,7 +35,7 @@ from todoist.managers.uploads import UploadsManager
 from todoist.managers.user import UserManager
 from todoist.managers.user_settings import UserSettingsManager
 
-DEFAULT_API_VERSION = "v8"
+DEFAULT_API_VERSION = "v9"
 
 
 class SyncError(Exception):


### PR DESCRIPTION
I am aware that this package is now deprecated and only the RESTful python client is now supported. But updating the endpoint from v8 to v9 allowed me to continue to use this package as a dependency to todoist-habitica-sync. Would appreciate if this can be kept alive with minimal changes.